### PR TITLE
Fix savestate load method name mismatch due to debug mod update

### DIFF
--- a/SpeedRunQoL/KeyBinds.cs
+++ b/SpeedRunQoL/KeyBinds.cs
@@ -105,7 +105,7 @@ namespace SpeedRunQoL
                 return;
             }
             
-            saveStateManager.GetType().GetMethod("LoadState", BindingFlags.Instance | BindingFlags.Public)
+            saveStateManager.GetType().GetMethod("LoadSaveState", BindingFlags.Instance | BindingFlags.Public)
                 ?.Invoke(saveStateManager, args);
         }
 

--- a/SpeedRunQoL/SpeedRunQoL.cs
+++ b/SpeedRunQoL/SpeedRunQoL.cs
@@ -8,7 +8,7 @@ namespace SpeedRunQoL
     //debug doesnt do any of the dll loading so the mod needs to inherit from "Mod" so the modding api loads it
     public class SpeedRunQoL: Mod
     {
-        public override string GetVersion() => "v0.60";
+        public override string GetVersion() => "v0.61";
         internal static SpeedRunQoL instance { get; private set; }
         public override void Initialize()
         {


### PR DESCRIPTION
Fix for debug 1.4.10.3 (currently only on cc's fork, not merged into mainline debug)